### PR TITLE
バリデーションの実装（認証機能続き）

### DIFF
--- a/src/app/api/register/route.ts
+++ b/src/app/api/register/route.ts
@@ -7,7 +7,6 @@ const prisma = new PrismaClient()
 export async function POST(request: Request) {
   const body = await request.json()
   const { name, email, password } = body.data
-  console.log(body.data)
   if (!name || !email || !password) {
     return new NextResponse('入力に不備があります', { status: 400 })
   }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import './globals.css'
 import Header from '@/components/layouts/Header/Header'
 import NextAuthProvider from '@/lib/next-auth/NextAuthProvider'
 import { cn } from '@/lib/utils'
+import { Toaster } from '@/components/ui/toaster'
 
 const notoSansJP = Noto_Sans_JP({ subsets: ['latin'] })
 
@@ -21,6 +22,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <NextAuthProvider>
           <Header />
           {children}
+          <Toaster />
         </NextAuthProvider>
       </body>
     </html>

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,31 +1,12 @@
 'use client'
 
 import React, { useState } from 'react'
-import Link from 'next/link'
-import { useRouter } from 'next/navigation'
-import { Input } from '@/components/ui/input'
-import { Button } from '@/components/ui/button'
-import { signIn as signInByNextAuth } from 'next-auth/react'
 import { LoginForm } from '@/features/auth/components/LoginForm'
 
 function Login() {
-  const router = useRouter()
-  const [data, setData] = useState({
-    email: '',
-    password: '',
-  })
-
-  const loginUser = async (e: React.MouseEvent<HTMLElement, MouseEvent>) => {
-    e.preventDefault()
-    await signInByNextAuth('credentials', {
-      ...data,
-      redirect: false,
-    })
-  }
-
   return (
     <div className='flex flex-col m-auto w-1/4'>
-      <LoginForm onSuccess={() => router.push('/')} />
+      <LoginForm onSuccess={() => {}} />
     </div>
   )
 }

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -1,69 +1,15 @@
 'use client'
 
-import React, { useState } from 'react'
+import React from 'react'
 import { useRouter } from 'next/navigation'
-import Link from 'next/link'
-import { Input } from '@/components/ui/input'
-import { Button } from '@/components/ui/button'
+import { RegisterForm } from '@/features/auth/components/RegisterForm'
 
 function Register() {
   const router = useRouter()
-  const [data, setData] = useState({
-    name: '',
-    email: '',
-    password: '',
-  })
-
-  const registerUser = async (e: React.MouseEvent<HTMLElement, MouseEvent>) => {
-    e.preventDefault()
-    const response = await fetch('/api/register', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({ data }),
-    })
-    const userInfo = await response.json()
-    router.push('/login')
-  }
 
   return (
-    <div className='flex flex-col items-center w-1/3 m-auto'>
-      <div className='w-full space-y-5'>
-        <Input
-          type='text'
-          value={data.name}
-          required
-          onChange={(event) => setData({ ...data, name: event.target.value })}
-          placeholder='お名前'
-        />
-        <Input
-          type='email'
-          value={data.email}
-          required
-          onChange={(event) => setData({ ...data, email: event.target.value })}
-          placeholder='メールアドレス'
-        />
-        <Input
-          type='password'
-          value={data.password}
-          required
-          onChange={(event) => setData({ ...data, password: event.target.value })}
-          placeholder='パスワード'
-        />
-      </div>
-      <div className='w-full text-right mb-5'>
-        <p className='text-xs'>
-          ログインは<Link href='/login'>こちら</Link>
-        </p>
-      </div>
-      <Button
-        variant='outline'
-        onClick={registerUser}
-        disabled={!data.email || !data.password || !data.name}
-      >
-        新規登録
-      </Button>
+    <div className='flex flex-col m-auto w-1/4'>
+      <RegisterForm onSuccess={() => router.push('/login')} />
     </div>
   )
 }

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -1,15 +1,12 @@
 'use client'
 
 import React from 'react'
-import { useRouter } from 'next/navigation'
 import { RegisterForm } from '@/features/auth/components/RegisterForm'
 
 function Register() {
-  const router = useRouter()
-
   return (
     <div className='flex flex-col m-auto w-1/4'>
-      <RegisterForm onSuccess={() => router.push('/login')} />
+      <RegisterForm onSuccess={() => {}} />
     </div>
   )
 }

--- a/src/components/elements/Button/Button.tsx
+++ b/src/components/elements/Button/Button.tsx
@@ -4,12 +4,6 @@ import React, { ReactElement, forwardRef } from 'react'
 import { Button as ButtonComponent } from '@/components/ui/button'
 import { Spinner } from '../Spinner'
 
-const variants = {
-  primary: 'outline',
-  inverse: 'bg-white text-blue-600',
-  danger: 'bg-red-600 text-white',
-}
-
 const sizes = {
   sm: 'py-2 px-4 text-sm',
   md: 'py-2 px-6 text-md',
@@ -22,7 +16,15 @@ type IconProps =
   | { endIcon?: undefined; startIcon?: undefined }
 
 export type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
-  variant?: keyof typeof variants
+  variant?:
+    | 'outline'
+    | 'default'
+    | 'destructive'
+    | 'secondary'
+    | 'ghost'
+    | 'link'
+    | null
+    | undefined
   size?: keyof typeof sizes
   isLoading?: boolean
 } & IconProps
@@ -32,7 +34,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
     {
       type = 'button',
       className = '',
-      variant = 'primary',
+      variant = 'default',
       size = 'md',
       isLoading = false,
       startIcon,
@@ -45,12 +47,8 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       <ButtonComponent
         ref={ref}
         type={type}
-        className={clsx(
-          'flex justify-center items-center border border-gray-300 disabled:opacity-70 disabled:cursor-not-allowed rounded-md shadow-sm font-medium focus:outline-none hover:opacity-80',
-          variants[variant],
-          sizes[size],
-          className,
-        )}
+        variant={variant}
+        className={clsx(sizes[size], className)}
         {...props}
       >
         {isLoading && <Spinner size='sm' className='text-current' />}

--- a/src/components/elements/Form/Form.tsx
+++ b/src/components/elements/Form/Form.tsx
@@ -28,7 +28,7 @@ export const Form = <
   const methods = useForm<TFormValues>({ ...options, resolver: schema && zodResolver(schema) })
   return (
     <form
-      className={clsx('space-y-6', className)}
+      className={clsx('space-y-4', className)}
       onSubmit={methods.handleSubmit(onSubmit)}
       id={id}
     >

--- a/src/components/elements/Form/Input.tsx
+++ b/src/components/elements/Form/Input.tsx
@@ -3,22 +3,19 @@ import { UseFormRegisterReturn } from 'react-hook-form'
 
 import { FieldWrapper, FieldWrapperPassThroughProps } from './FieldWrapper'
 import { Input as InputComponent } from '@/components/ui/input'
-import { ChangeEvent } from 'react'
 
 type InputFieldProps = FieldWrapperPassThroughProps & {
   type?: 'text' | 'email' | 'password'
   className?: string
   registration: Partial<UseFormRegisterReturn>
-  onChange?: (e: ChangeEvent<HTMLInputElement>) => void
 }
 
 export const Input = (props: InputFieldProps) => {
-  const { type = 'text', label, className, registration, onChange, error } = props
+  const { type = 'text', label, className, registration, error } = props
   return (
     <FieldWrapper label={label} error={error}>
       <InputComponent
         type={type}
-        onChange={onChange}
         className={clsx(
           'appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm',
           className,

--- a/src/features/auth/components/LoginForm.tsx
+++ b/src/features/auth/components/LoginForm.tsx
@@ -1,17 +1,18 @@
 'use client'
 
-import React, { useState } from 'react'
+import React from 'react'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import * as z from 'zod'
 import { useSession, signIn } from 'next-auth/react'
+import { useToast } from '@/components/ui/use-toast'
 
 import { Button } from '@/components/elements/Button'
 import { Form, Input } from '@/components/elements/Form'
 
 const schema = z.object({
-  email: z.string().min(1, '1文字以上で入力してください'),
-  password: z.string().min(6, '6文字以上で入力してください'),
+  email: z.string().min(1, '入力してください'),
+  password: z.string().min(1, '入力してください'),
 })
 
 type LoginValues = {
@@ -24,22 +25,25 @@ type LoginFormProps = {
 }
 
 export const LoginForm = ({ onSuccess }: LoginFormProps) => {
+  const { toast } = useToast()
   const router = useRouter()
   const { data: session } = useSession()
   const loginUser = async (data: LoginValues) => {
-    console.log(data)
     await signIn('credentials', {
       ...data,
       redirect: false,
     })
     router.push('/')
   }
+
+  const onSubmit = async (values: LoginValues) => {
+    await loginUser(values)
+  }
   return (
     <div>
       <Form<LoginValues, typeof schema>
         onSubmit={async (values) => {
-          await loginUser(values)
-          onSuccess()
+          await onSubmit(values)
         }}
         schema={schema}
       >

--- a/src/features/auth/components/LoginForm.tsx
+++ b/src/features/auth/components/LoginForm.tsx
@@ -4,7 +4,7 @@ import React from 'react'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import * as z from 'zod'
-import { useSession, signIn } from 'next-auth/react'
+import { useSession, signIn, SignInResponse } from 'next-auth/react'
 import { useToast } from '@/components/ui/use-toast'
 
 import { Button } from '@/components/elements/Button'
@@ -32,8 +32,16 @@ export const LoginForm = ({ onSuccess }: LoginFormProps) => {
     await signIn('credentials', {
       ...data,
       redirect: false,
+    }).then((res: SignInResponse | undefined) => {
+      if (res && res.status === 200) {
+        router.push('/')
+      } else if (res?.status === 401) {
+        toast({
+          description: 'ログインに失敗しました',
+          variant: 'destructive',
+        })
+      }
     })
-    router.push('/')
   }
 
   const onSubmit = async (values: LoginValues) => {

--- a/src/features/auth/components/LoginForm.tsx
+++ b/src/features/auth/components/LoginForm.tsx
@@ -62,7 +62,7 @@ export const LoginForm = ({ onSuccess }: LoginFormProps) => {
               registration={register('password')}
             />
             <div>
-              <Button isLoading={!!session} type='submit' className='w-full'>
+              <Button isLoading={!!session} type='submit' className='w-full mt-6'>
                 ログイン
               </Button>
             </div>

--- a/src/features/auth/components/RegisterForm.tsx
+++ b/src/features/auth/components/RegisterForm.tsx
@@ -71,7 +71,7 @@ export const RegisterForm = ({ onSuccess }: RegisterFormProps) => {
               registration={register('password')}
             />
             <div>
-              <Button type='submit' className='w-full'>
+              <Button type='submit' className='w-full mt-6'>
                 新規登録
               </Button>
             </div>

--- a/src/features/auth/components/RegisterForm.tsx
+++ b/src/features/auth/components/RegisterForm.tsx
@@ -1,0 +1,91 @@
+'use client'
+
+import * as React from 'react'
+import * as z from 'zod'
+
+import { Button } from '@/components/elements/Button'
+import { Form, Input } from '@/components/elements/Form'
+import Link from 'next/link'
+import { useRouter } from 'next/navigation'
+import { signIn } from 'next-auth/react'
+
+const schema = z.object({
+  name: z.string().min(1, '必須項目です'),
+  email: z.string().min(1, '必須項目です'),
+  password: z.string().min(6, '6文字以上で入力してください'),
+})
+
+type RegisterValues = {
+  name: string
+  email: string
+  password: string
+}
+
+type RegisterFormProps = {
+  onSuccess: () => void
+}
+
+export const RegisterForm = ({ onSuccess }: RegisterFormProps) => {
+  const router = useRouter()
+  const registerUser = async (data: RegisterValues) => {
+    const response = await fetch('/api/register', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ data }),
+    })
+    const userInfo = await response.json()
+  }
+
+  return (
+    <div>
+      <Form<RegisterValues, typeof schema>
+        onSubmit={async (values) => {
+          await registerUser(values)
+          onSuccess()
+        }}
+        schema={schema}
+        options={{
+          shouldUnregister: true,
+        }}
+      >
+        {({ register, formState }) => (
+          <>
+            <Input
+              type='text'
+              label='お名前'
+              error={formState.errors['name']}
+              registration={register('name')}
+            />
+            <Input
+              type='email'
+              label='メールアドレス'
+              error={formState.errors['email']}
+              registration={register('email')}
+            />
+            <Input
+              type='password'
+              label='パスワード'
+              error={formState.errors['password']}
+              registration={register('password')}
+            />
+            <div>
+              <Button type='submit' className='w-full'>
+                新規登録
+              </Button>
+            </div>
+          </>
+        )}
+      </Form>
+      <div className='mt-2 flex items-center justify-end'>
+        <div className='text-sm'>
+          ログイン画面は
+          <Link href='/login' className='font-medium text-blue-600 hover:text-blue-500'>
+            こちら
+          </Link>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/features/auth/components/RegisterForm.tsx
+++ b/src/features/auth/components/RegisterForm.tsx
@@ -8,6 +8,7 @@ import { Form, Input } from '@/components/elements/Form'
 import Link from 'next/link'
 import { signIn } from 'next-auth/react'
 import { useRouter } from 'next/navigation'
+import { useToast } from '@/components/ui/use-toast'
 
 const schema = z.object({
   name: z.string().min(1, '必須項目です'),
@@ -26,6 +27,7 @@ type RegisterFormProps = {
 }
 
 export const RegisterForm = ({ onSuccess }: RegisterFormProps) => {
+  const { toast } = useToast()
   const router = useRouter()
   const registerUser = async (data: RegisterValues) => {
     await fetch('/api/register', {
@@ -35,12 +37,17 @@ export const RegisterForm = ({ onSuccess }: RegisterFormProps) => {
       },
       body: JSON.stringify({ data }),
     }).then(async (res: Response) => {
-      if (res) {
+      if (res.status === 200) {
         await signIn('credentials', {
           ...data,
           redirect: false,
         })
         router.push('/')
+      } else if (res.status === 400) {
+        toast({
+          description: '新規登録に失敗しました',
+          variant: 'destructive',
+        })
       }
     })
   }

--- a/src/features/auth/components/RegisterForm.tsx
+++ b/src/features/auth/components/RegisterForm.tsx
@@ -6,8 +6,8 @@ import * as z from 'zod'
 import { Button } from '@/components/elements/Button'
 import { Form, Input } from '@/components/elements/Form'
 import Link from 'next/link'
-import { useRouter } from 'next/navigation'
 import { signIn } from 'next-auth/react'
+import { useRouter } from 'next/navigation'
 
 const schema = z.object({
   name: z.string().min(1, '必須項目です'),
@@ -28,14 +28,21 @@ type RegisterFormProps = {
 export const RegisterForm = ({ onSuccess }: RegisterFormProps) => {
   const router = useRouter()
   const registerUser = async (data: RegisterValues) => {
-    const response = await fetch('/api/register', {
+    await fetch('/api/register', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
       },
       body: JSON.stringify({ data }),
+    }).then(async (res: Response) => {
+      if (res) {
+        await signIn('credentials', {
+          ...data,
+          redirect: false,
+        })
+        router.push('/')
+      }
     })
-    const userInfo = await response.json()
   }
 
   return (


### PR DESCRIPTION
## 実装の概要

以下のとおり、実装。

- zod, react-hook-formを使用してバリデーション付きフォームを実装
- 新規登録と同時にログイン認証処理も実装
- 既に認証済みのEmailの場合にエラーポップを表示

## Issue

- #12 

## 実装理由・気づき

- いい感じにできた。

## 最後に

close #12 
